### PR TITLE
Fixed golang readme mentioning python runtime

### DIFF
--- a/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
+++ b/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
@@ -66,7 +66,7 @@ Events:
 
 ## Packaging and deployment
 
-AWS Lambda Python runtime requires a flat folder with all dependencies including the application. SAM will use `CodeUri` property to know where to look up for both application and dependencies:
+AWS Lambda Golang runtime requires a flat folder with the executable generated on build step. SAM will use `CodeUri` property to know where to look up for the application:
 
 ```yaml
 ...


### PR DESCRIPTION
Current golang readme is mentioning python runtime instead of golang. Small fix to correct it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
