### PR TITLE
fix: add go.mod for the go sam init templates

### DIFF
--- a/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/hello-world/go.mod
+++ b/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/hello-world/go.mod
@@ -1,0 +1,4 @@
+require github.com/aws/aws-lambda-go v1.13.3
+
+module hello-world
+


### PR DESCRIPTION
Why is this change necessary?

* `sam build` fails with Error: GoModulesBuilder:Build - Builder Failed: can't load package: package /Users/localuser/workspace/apps/go-1.x/hello-world: import "/Users/localuser/workspace/apps/go-1.x/hello-world": cannot import absolute path

How does it address the issue?

* Adds the necessary `go.mod` file

What side effects does this change have?

* None

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
