### PR TITLE
Fix Topic Arn reference from GetAtt to !Ref

### DIFF
--- a/nodejs10.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/template.yml
+++ b/nodejs10.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/template.yml
@@ -34,7 +34,7 @@ Resources:
         SNSTopicEvent:
           Type: SNS
           Properties:
-            Topic: Fn::GetAtt SimpleTopic.Arn
+            Topic: !Ref SimpleTopic
       MemorySize: 128
       Timeout: 100
       Policies:

--- a/nodejs12.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/template.yml
+++ b/nodejs12.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/template.yml
@@ -34,7 +34,7 @@ Resources:
         SNSTopicEvent:
           Type: SNS
           Properties:
-            Topic: Fn::GetAtt SimpleTopic.Arn
+            Topic: !Ref SimpleTopic
       MemorySize: 128
       Timeout: 100
       Policies:


### PR DESCRIPTION
*Issue* 
SAM deploy of this quick start fails with the exception  'An ARN must have at least 6 elements, not 3'

*Description of changes:*
As per the[ AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html)  Fn::GetAtt SimpleTopic only returns the 'Topic name' and not an ARN. This must be replaced by the !Ref intrinsic function which returns the ARN to deploy successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
